### PR TITLE
Wrap the arrow function in brackets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = class Retrier {
         this.step = opts.step || STEP;
         this.sleep = opts.sleep || sleep;
         this.logger = opts.logger || { error: function(){} };
-        this.shouldRetry = opts.shouldRetry || () => true;
+        this.shouldRetry = opts.shouldRetry || (() => true);
     }
 
     *_attempt() {


### PR DESCRIPTION
When using the || operation and an arrow function in Node 6, the arrow function part has to be wrapped with parenthesis -
https://github.com/nodejs/node/issues/6892

When wrapping in parenthesis, the code works in both Node 6 & Node 4
