### PR TITLE
feature(v2): changed conf api. throw error on fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 4
+  - 5
+  - 6

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Exponential Backoff.  Well, turns out it isn't the wisest decision, and adding
 jitter to your backoff strategy can help you a lot. Read more
 about it here: https://www.awsarchitectureblog.com/2015/03/backoff.html.
 
+### Updates
+
+Version 2.0.0:
+- Changed max argument name to "max_attempts". It now counts total runs of function instead of total retries.
+- Retrier.run() will now throw the last error in case the last attempts doesn't succeed. 
+
 ### Install
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "co-jitter-retry",
   "description": "Retry generators with full jitter",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "co-jitter-retry",
-  "description": "Retry generators with full jitter",
-  "version": "2.0.0",
   "description": "",
+  "version": "2.0.0",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha tests/**/*.spec.js"
+    "test": "node_modules/mocha/bin/mocha 'tests/**/**.spec.js'"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +21,7 @@
     "chai": "^3.5.0",
     "co": "^4.6.0",
     "co-mocha": "^1.1.3",
+    "mocha": "^3.2.0",
     "sinon": "^1.17.5",
     "sinon-as-promised": "^4.0.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = class Retrier {
         this.method = method;
         this.args = args;
         this.attempt = 0;
-        this.max = opts.max || MAX_ATTEMPTS;
+        this.max_attempts = opts.max_attempts || MAX_ATTEMPTS;
         this.step = opts.step || STEP;
         this.sleep = opts.sleep || sleep;
         this.logger = opts.logger || { error: function(){} };
@@ -28,12 +28,14 @@ module.exports = class Retrier {
     }
 
     *run() {
-        for(let i = 0; i <= this.max; i++) {
+        let lastError;
+        for(let i = 0; i < this.max_attempts; i++) {
             try {
                 return (yield this._attempt())
             } catch(err) {
+              lastError = err;
               if( ! this.shouldRetry(err) ) {
-                throw err;
+                throw lastError;
               } else {
                 this.attempt++;
                 let slp = this._calc_sleep();
@@ -43,5 +45,7 @@ module.exports = class Retrier {
               }
             }
         }
+
+        throw lastError
     }
 }


### PR DESCRIPTION
Breaking changes to the API, hence the new top level version

Version 2.0.0:
- Changed max argument name to "max_attempts". It now counts total runs of function instead of total retries.
- Retrier.run() will now throw the last error in case the last attempts doesn't succeed. 
